### PR TITLE
Harden simulation helpers

### DIFF
--- a/simulationCases/dropImpact-EVP.c
+++ b/simulationCases/dropImpact-EVP.c
@@ -254,6 +254,8 @@ event logWriting (i++) {
 
       fprintf(ferr, "%s", message);
 
+      dump(file=dump_file);
+
       fp = fopen("log", "a");
       if (fp == NULL) {
         fprintf(ferr, "Error opening log file 'log': %s\n",
@@ -264,7 +266,6 @@ event logWriting (i++) {
       fflush(fp);
       fclose(fp);
 
-      dump(file=dump_file);
       return 1;
     }
   }

--- a/simulationCases/dropImpact-EVP.c
+++ b/simulationCases/dropImpact-EVP.c
@@ -30,6 +30,9 @@ Date: Feb 09, 2026
 #include "tension.h"
 #include "case-params.h"
 
+#include <errno.h>
+#include <string.h>
+
 /**
 ## Output Cadence
 */
@@ -216,7 +219,8 @@ event logWriting (i++) {
     const char* mode = (i == 0) ? "w" : "a";
     fp = fopen(logFile, mode);
     if (fp == NULL) {
-      fprintf(ferr, "Error opening log file\n");
+      fprintf(ferr, "Error opening log file '%s': %s\n",
+              logFile, strerror(errno));
       return 1;
     }
 
@@ -251,6 +255,11 @@ event logWriting (i++) {
       fprintf(ferr, "%s", message);
 
       fp = fopen("log", "a");
+      if (fp == NULL) {
+        fprintf(ferr, "Error opening log file 'log': %s\n",
+                strerror(errno));
+        return 1;
+      }
       fprintf(fp, "%s", message);
       fflush(fp);
       fclose(fp);

--- a/simulationCases/runCases.sh
+++ b/simulationCases/runCases.sh
@@ -13,6 +13,11 @@ CASE_PATH="simulationCases/${CASE_NAME}.c"
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 REPO_ROOT=$(cd "${SCRIPT_DIR}/.." && pwd)
 
+if [ ! -f "${REPO_ROOT}/${CASE_PATH}" ]; then
+  echo "Error: case file not found: ${CASE_PATH}" >&2
+  exit 1
+fi
+
 if [ "$#" -eq 2 ]; then
   "${REPO_ROOT}/runSimulation.sh" --case "$CASE_PATH" --input "$2"
 else

--- a/src-local/log-conform-elastoviscoplastic-HB-scalar-2D.h
+++ b/src-local/log-conform-elastoviscoplastic-HB-scalar-2D.h
@@ -221,14 +221,14 @@ event defaults (i = 0) {
 
   for (scalar s in {T11, T12, T22}) {
     if (s.boundary[left] != periodic_bc) {
-        s[left] = neumann(0);
+      s[left] = neumann(0);
       s[right] = neumann(0);
-      }
+    }
   }
 
   for (scalar s in {A11, A12, A22}) {
     if (s.boundary[left] != periodic_bc) {
-        s[left] = neumann(0);
+      s[left] = neumann(0);
       s[right] = neumann(0);
     }
   }

--- a/src-local/log-conform-elastoviscoplastic-HB-scalar-2D.h
+++ b/src-local/log-conform-elastoviscoplastic-HB-scalar-2D.h
@@ -222,14 +222,14 @@ event defaults (i = 0) {
   for (scalar s in {T11, T12, T22}) {
     if (s.boundary[left] != periodic_bc) {
         s[left] = neumann(0);
-	      s[right] = neumann(0);
+      s[right] = neumann(0);
       }
   }
 
   for (scalar s in {A11, A12, A22}) {
     if (s.boundary[left] != periodic_bc) {
         s[left] = neumann(0);
-	      s[right] = neumann(0);
+      s[right] = neumann(0);
     }
   }
 

--- a/src-local/log-conform-elastoviscoplastic-HB-scalar-3D.h
+++ b/src-local/log-conform-elastoviscoplastic-HB-scalar-3D.h
@@ -247,16 +247,16 @@ event defaults (i = 0) {
   for (scalar s in {A11, A22, A33, T11, T22, T33, A12, A13, A23, T12, T13, T23}) {
     if (s.boundary[left] != periodic_bc) {
       s[left] = neumann(0);
-	    s[right] = neumann(0);
+      s[right] = neumann(0);
     }
     if (s.boundary[top] != periodic_bc) {
       s[top] = neumann(0);
-	    s[bottom] = neumann(0);
+      s[bottom] = neumann(0);
     }
 #if dimension == 3
     if (s.boundary[front] != periodic_bc) {
       s[front] = neumann(0);
-	    s[back] = neumann(0);
+      s[back] = neumann(0);
     }
 #endif
   }


### PR DESCRIPTION
## Summary
- Add a safety check before `runCases.sh` launches a case
- Clean up lingering tab indentation in the EVP-HB headers
- Improve log-file error reporting in the EVP runner

## Changes
- `runCases.sh` now exits early if the case source file is missing
- The HB scalar headers now use 2-space indentation in boundary setup
- `dropImpact-EVP.c` reports `fopen` failures with filenames and `errno`

## Testing
- `bash -n simulationCases/runCases.sh`
- `git diff --check`